### PR TITLE
Publish to Open VSX in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       - run: pnpm i
 
       - name: Create Release Pull Request
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm run version
@@ -37,3 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           AZURE_TOKEN: ${{ secrets.AZURE_TOKEN }}
+
+      - name: Publish to OpenVSX
+        if: steps.changesets.outputs.published == 'true'
+        run: npx ovsx publish -p ${{ secrets.OVSX_TOKEN }} --target win32-x64 win32-arm64 linux-x64 linux-arm64 linux-armhf darwin-x64 darwin-arm64 alpine-x64 alpine-arm64


### PR DESCRIPTION
Closes #12

Adds a step to the release workflow to also publish to Open VSX.

Vaguely modelled on https://github.com/withastro/language-tools/blob/7e5ccb70a59b0449048295b24e8cb4742063f6b0/.github/workflows/release.yml#L57-L62 and https://github.com/eclipse/openvsx/wiki/Publishing-Extensions

#### To do

- [x] Add `OVSX_TOKEN` secret