### PR TITLE
Proposal for 🐛 Bug Report Issue Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUGS.yml
+++ b/.github/ISSUE_TEMPLATE/BUGS.yml
@@ -8,8 +8,8 @@ body:
     attributes:
       value: |
         ```
-        ╭─────╮    > Thank you for reporting your issue! 
-        │ ◠ ◡ ◠
+        ╭─────╮
+        │ ◠ ◡ ◠   Thank you for reporting your issue! 
         ╰─────╯
         ```
   - type: input

--- a/.github/ISSUE_TEMPLATE/BUGS.yml
+++ b/.github/ISSUE_TEMPLATE/BUGS.yml
@@ -7,24 +7,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for reporting your issue! Houston appreciates your assistance. 🚀
         ```
-        ╭─────╮
+        ╭─────╮    > Thank you for reporting your issue! 
         │ ◠ ◡ ◠
         ╰─────╯
         ```
-  - type: dropdown
-    id: type
-    attributes:
-      label: "❓ Issue Type"
-      description: Is this a visual issue or a problem with the extension? If `other`, please specify in the description.
-      options:
-        - Visual
-        - Extension
-        - Other
-      default: 0
-    validations:
-      required: true
   - type: input
     id: location
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUGS.yml
+++ b/.github/ISSUE_TEMPLATE/BUGS.yml
@@ -8,6 +8,11 @@ body:
     attributes:
       value: |
         Thank you for reporting your issue! Houston appreciates your assistance. 🚀
+        ```
+        ╭─────╮
+        │ ◠ ◡ ◠
+        ╰─────╯
+        ```
   - type: dropdown
     id: type
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUGS.yml
+++ b/.github/ISSUE_TEMPLATE/BUGS.yml
@@ -1,0 +1,51 @@
+name: "🐛 Bug Report"
+description: Report an issue with the extension or possible visual bug.
+labels: [
+  "bug"
+]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting your issue! Houston appreciates your assistance. 🚀
+  - type: dropdown
+    id: type
+    attributes:
+      label: "❓ Issue Type"
+      description: Is this a visual issue or a problem with the extension? If `other`, please specify in the description.
+      options:
+        - Visual
+        - Extension
+        - Other
+      default: 0
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: "🔎 Issue Location"
+      description: Please indicate where in the window the issue occurs.
+      placeholder: Scrollbar, editor, menubar, semantic highlighting, etc...
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: "📝 Issue Description"
+      description: Please describe the issue.
+      placeholder: Description of your observation...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: "🤔 Expected Behavior"
+      description: Please describe what the expected behavior should be.
+      placeholder: When viewing this part of the editor, I would expect...
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: "📋 Additional Information"
+      description: Please provide any additional information you can provide (images, logs, etc.). Please wrap logs in backticks for readability.


### PR DESCRIPTION
### Description

Adds an issue template using GitHub's beta forms feature.
This is an effort to standardize issue reports with the other main repos such as `astro` and `docs`.

My apologies if it's terrible, its my first issue template! I would love to implement feedback! 

I will also draft one up for feature requests.

Here is the rendered form:
![preview](https://github.com/withastro/houston-vscode/assets/20650404/f0d8344b-2bce-4904-9909-8d39b170a2b3)

